### PR TITLE
Add support for wtg time step (update forcing every certain steps)

### DIFF
--- a/params.f90
+++ b/params.f90
@@ -236,6 +236,8 @@ logical :: doadvensnoise = .false. ! works with dompiensemble, use the large-sca
 ! temporal parameters for wtg
 integer :: nstartwtg = 0 ! nstep to start wtg calculation
 integer :: nstepwtgbg = 0 ! nstep after nstartwtg to calculate wtg background profile
+integer :: nstepwtg = 999999999 ! keep constant wtg forcing in this many steps
+logical :: dowtgtimestep = .false.
 
 ! Options for large-scale vertical advection of temperature/moisture, u/v wind
 logical :: dotqlsvadv = .false.

--- a/wtg_jas2008.f90
+++ b/wtg_jas2008.f90
@@ -3,7 +3,7 @@
 !
 !   http://dx.doi.org/10.1175/2007JAS2399.1
 
-subroutine wtg_jas2008(nzm, dtn, z, zi, rho, tabs_ref, qv_ref, tabs_model, &
+subroutine wtg_jas2008(nzm, timestep, z, zi, rho, tabs_ref, qv_ref, tabs_model, &
      qv_model, qcond_model, lambda_wtg, am_wtg, w_ls, dwdt_ls)
 
   use grid, only: icycle, ncycle, nsubdomains
@@ -13,7 +13,7 @@ subroutine wtg_jas2008(nzm, dtn, z, zi, rho, tabs_ref, qv_ref, tabs_model, &
 
   ! ======= inputs =======
   integer, intent(in) :: nzm ! number of model levels
-  real, intent(in) :: dtn ! current dynamical time step
+  real, intent(in) :: timestep ! current dynamical time step
   real, intent(in) :: z(nzm) ! model cell center height
   real, intent(in) :: zi(nzm+1) ! model interface height
   real, intent(in) :: rho(nzm) ! model cell center density
@@ -121,7 +121,7 @@ subroutine wtg_jas2008(nzm, dtn, z, zi, rho, tabs_ref, qv_ref, tabs_model, &
 
    if (dowtg_timedependence) then
 
-      w_ls(1:nzm) = (w_ls(1:nzm) + dwdt_ls * dtn) / (1. + dtn * am_wtg)
+      w_ls(1:nzm) = (w_ls(1:nzm) + dwdt_ls * timestep) / (1. + timestep * am_wtg)
 
    else
 


### PR DESCRIPTION
To use this feature, set `dowtgtimestep` to True and set `nstepwtg` to an integer number.
- This will make the WTG large-scale w and omega constant in this many steps before the next update.
- The advective tendencies of 1d profiles are also kept constant / updated at the same time.
- `nstepwtg` should be a multiple of `nstat`
- The output WTG tendencies are valid for the current and `nstepwtg-1` previous steps. 
- The output WTG profiles are calculated based on the fields at the end of `nstep-nstepwtg` step (without being affected by the WTG tendencies output at the same step).
- The other default SAM outputs are calculated based on the fields at the end of the current step (with full effect from the WTG tendencies output at the same step).