### PR TITLE
Modify default values and output hbuf init for WTG

### DIFF
--- a/hbuf_conditionals_init.f90
+++ b/hbuf_conditionals_init.f90
@@ -28,6 +28,19 @@ subroutine hbuf_conditionals_init(count,trcount)
          'Large-scale Omega induced by weak temperature gradient approx','Pa/s',0)
     call add_to_namelist(count,trcount,'WOBSREF', &
          'Reference Large-scale W Before Modifications by WTG/Scaling','m/s',0)
+    call add_to_namelist(count,trcount,'T_WTG', &
+         'Temperature before wtg forcing','K',0)
+    call add_to_namelist(count,trcount,'QV_WTG', &
+         'Water vapor before wtg forcing','g/kg',0)
+    call add_to_namelist(count,trcount,'QC_WTG', &
+         'Water condensate (qn+qp) before wtg forcing','g/kg',0)
+    ! the followings can be different from the above with doadvensnoise
+    call add_to_namelist(count,trcount,'T_WTG_W', &
+         'Temperature used in wtg calculation','K',0)
+    call add_to_namelist(count,trcount,'QV_WTG_W', &
+         'Water vapor used in wtg calculation','g/kg',0)
+    call add_to_namelist(count,trcount,'QC_WTG_W', &
+         'Water condensate (qn+qp) used in wtg calculation','g/kg',0)
   end if
 
   if(dowtg_raymondzeng_QJRMS2005) then

--- a/params.f90
+++ b/params.f90
@@ -224,10 +224,10 @@ real    :: zhadmax  = 15000.
 real    :: hadscale_time = 0.
 
 ! Option for whether to advect 1d profile for wtg advection
-logical :: doadv3d = .false. ! this was true in the vanilla SAM
+logical :: doadv3d = .true. ! this was true in the vanilla SAM
 
 ! Options for which 1d profile to advect if advecting 1d
-logical :: doadvinic = .false. ! advect initial profile
+logical :: doadvinic = .true. ! advect initial profile
 logical :: docalcwtgbg = .false. ! even if not doadvbg, may still want to calculate the wtg bg
 logical :: doadvbg = .false. ! advect computed background (time-invariant)
 logical :: doadvensnoise = .false. ! works with dompiensemble, use the large-scale w from one ensemble member
@@ -240,8 +240,8 @@ integer :: nstepwtg = 999999999 ! keep constant wtg forcing in this many steps
 logical :: dowtgtimestep = .false.
 
 ! Options for large-scale vertical advection of temperature/moisture, u/v wind
-logical :: dotqlsvadv = .false.
-logical :: douvlsvadv = .false.
+logical :: dotqlsvadv = .true.
+logical :: douvlsvadv = .true.
 
 ! Kuang-Lab Additions End Here
 !=====================================================

--- a/setparm.f90
+++ b/setparm.f90
@@ -311,9 +311,12 @@ end if
               write(*,*) '********************************************************'
               write(*,*) '  Unsupported setup in large-scale vertical advection'
               write(*,*) '  Please confirm subsidence 1d or 3d fields.'
+              write(*,*) '  Setting both doadvinic and doadvbg to false.'
               write(*,*) '********************************************************'
             end if
-            call task_abort()
+            !call task_abort()
+            doadvinic = .false.
+            doadvbg = .false.
           end if
         else if (doadvinic.and.doadvbg) then
           if (masterproc) then

--- a/statistics.f90
+++ b/statistics.f90
@@ -224,11 +224,6 @@ real, dimension(nzm) :: rhowcl, rhowmsecl, rhowtlcl, rhowqtcl,  &
 	! Add bias outputs to statistics as per Blossey version of SAM
 	call hbuf_put('TBIAS',tabs0-tg0,1.)
 	call hbuf_put('QBIAS',factor_xy*(qvz+qcz)-qg0,1.e3)
-        ! Add profiles before forcing
-        call hbuf_put('T_WTG',t_wtg,1.)
-        call hbuf_put('QV_WTG',q_wtg,1.e3)
-        call hbuf_put('T_WTG_W', t_wtg_calcw,1.)
-        call hbuf_put('QV_WTG_W', q_wtg_calcw,1.e3)
 
 !-------------------------------------------------------------
 !	Fluxes:
@@ -1235,6 +1230,14 @@ real, dimension(nzm) :: rhowcl, rhowmsecl, rhowtlcl, rhowqtcl,  &
 		call hbuf_put('WWTG',w_wtg,1.)
 		call hbuf_put('OWTG',o_wtg,1.)
 		call hbuf_put('WOBSREF',wsub_ref,1.)
+		! Add profiles before forcing
+        call hbuf_put('T_WTG',t_wtg,1.)
+        call hbuf_put('QV_WTG',q_wtg,1.e3)
+		call hbuf_put('QC_WTG',qcond_wtg,1.e3)
+		! Add profiles for calculating wtg, can be different with doadvensnoise
+        call hbuf_put('T_WTG_W', t_wtg_calcw,1.)
+        call hbuf_put('QV_WTG_W', q_wtg_calcw,1.e3)
+		call hbuf_put('QC_WTG_W', qcond_wtg_calcw,1.e3)
 	end if
 
 	if(dowtg_raymondzeng_QJRMS2005) then


### PR DESCRIPTION
1. The default values now make the model the same as vanilla SAM in large-scale vertical advection forcing.
2. Add temperature, vapor, and condensate for WTG to hbuf_conditionals_init so that no need to manually add those output names to lst file.